### PR TITLE
feat(web): add interactive 404 experience

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { NotFound as PageNotFound } from "@/components/not-found";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+};
+
+const NotFound = () => <PageNotFound />;
+
+export default NotFound;

--- a/apps/web/components/daikanoid/ball.ts
+++ b/apps/web/components/daikanoid/ball.ts
@@ -1,0 +1,169 @@
+import type { Brick } from "./brick";
+import type { GameColors } from "./colors";
+import {
+  BALL_RADIUS,
+  BALL_SPEED,
+  BRICK_SCORE,
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  PADDLE_Y,
+  SOUND_VOLUME,
+  uncheckedClamp,
+} from "./constants";
+import type { Paddle } from "./paddle";
+import type { GameState } from "./types";
+
+const playSound = async (sound: HTMLAudioElement) => {
+  sound.currentTime = 0;
+  sound.volume = SOUND_VOLUME;
+
+  try {
+    await sound.play();
+  } catch {
+    // Browsers can block audio until the user has interacted with the canvas.
+  }
+};
+
+export class Ball {
+  radius = BALL_RADIUS;
+  x = CANVAS_WIDTH / 2;
+  y = PADDLE_Y - 56;
+  xSpeed = 0;
+  ySpeed = 0;
+
+  private state: GameState;
+
+  constructor(state: GameState) {
+    this.state = state;
+    this.reset();
+  }
+
+  show(context: CanvasRenderingContext2D, colors: GameColors) {
+    context.fillStyle = colors.foreground;
+    context.beginPath();
+    context.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+    context.fill();
+
+    context.save();
+    context.globalAlpha = 0.35;
+    context.fillStyle = colors.background;
+    context.fillRect(this.x - 4, this.y - 5, 4, 3);
+    context.restore();
+  }
+
+  move(frameScale: number) {
+    this.x += this.xSpeed * frameScale;
+    this.y += this.ySpeed * frameScale;
+  }
+
+  checkEdges() {
+    if (this.x <= this.radius || this.x >= CANVAS_WIDTH - this.radius) {
+      this.x = uncheckedClamp(this.radius, CANVAS_WIDTH - this.radius, this.x);
+      this.xSpeed *= -1;
+      this.playBounceSound();
+    }
+
+    if (this.y <= this.radius) {
+      this.y = this.radius;
+      this.ySpeed = Math.abs(this.ySpeed);
+      this.playBounceSound();
+    }
+
+    if (this.y - this.radius > CANVAS_HEIGHT) {
+      this.state.enableGame = false;
+      if (this.state.enableSounds) {
+        void playSound(this.state.soundGameOver);
+      }
+      this.reset();
+    }
+  }
+
+  checkPaddle(paddle: Paddle) {
+    if (
+      this.ySpeed <= 0 ||
+      this.y + this.radius < paddle.y ||
+      this.y - this.radius > paddle.y + paddle.height ||
+      this.x < paddle.x ||
+      this.x > paddle.x + paddle.width
+    ) {
+      return;
+    }
+
+    const hit = uncheckedClamp(
+      -1,
+      1,
+      (this.x - (paddle.x + paddle.width / 2)) / (paddle.width / 2)
+    );
+    this.y = paddle.y - this.radius;
+    this.xSpeed = hit * BALL_SPEED * 0.85;
+    this.ySpeed = -Math.sqrt(BALL_SPEED ** 2 - this.xSpeed ** 2);
+    this.playBounceSound();
+  }
+
+  checkBricks() {
+    let collision: Brick | undefined;
+
+    for (let index = this.state.bricks.length - 1; index >= 0; index -= 1) {
+      const brick = this.state.bricks[index];
+      if (!this.overlaps(brick)) {
+        continue;
+      }
+
+      collision ??= brick;
+      this.state.bricks.splice(index, 1);
+      this.state.score += BRICK_SCORE;
+      if (this.state.enableSounds) {
+        void playSound(this.state.soundBreak);
+      }
+    }
+
+    if (collision) {
+      this.bounceFrom(collision);
+    }
+    if (this.state.bricks.length === 0) {
+      this.state.enableGame = false;
+    }
+  }
+
+  reset() {
+    const direction = Math.random() < 0.5 ? -1 : 1;
+    const horizontalSpeed = (2.5 + Math.random() * 2.5) * direction;
+
+    this.x = CANVAS_WIDTH / 2;
+    this.y = PADDLE_Y - 56;
+    this.xSpeed = horizontalSpeed;
+    this.ySpeed = -Math.sqrt(BALL_SPEED ** 2 - horizontalSpeed ** 2);
+  }
+
+  private overlaps(brick: Brick) {
+    return (
+      this.x + this.radius > brick.x &&
+      this.x - this.radius < brick.x + brick.w &&
+      this.y + this.radius > brick.y &&
+      this.y - this.radius < brick.y + brick.h
+    );
+  }
+
+  private bounceFrom(brick: Brick) {
+    const horizontalOverlap = Math.min(
+      this.x + this.radius - brick.x,
+      brick.x + brick.w - (this.x - this.radius)
+    );
+    const verticalOverlap = Math.min(
+      this.y + this.radius - brick.y,
+      brick.y + brick.h - (this.y - this.radius)
+    );
+
+    if (horizontalOverlap < verticalOverlap) {
+      this.xSpeed *= -1;
+    } else {
+      this.ySpeed *= -1;
+    }
+  }
+
+  private playBounceSound() {
+    if (this.state.enableSounds) {
+      void playSound(this.state.soundBounce);
+    }
+  }
+}

--- a/apps/web/components/daikanoid/brick.ts
+++ b/apps/web/components/daikanoid/brick.ts
@@ -1,0 +1,52 @@
+import type { GameColors } from "./colors";
+import { BRICK_SIZE, CANVAS_WIDTH, LOGO_COLUMNS, LOGO_TOP } from "./constants";
+import { loadLogoPattern } from "./logos";
+import type { GameState } from "./types";
+
+export class Brick {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+
+  constructor(x: number, y: number, w: number, h: number) {
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+  }
+
+  show(context: CanvasRenderingContext2D, colors: GameColors) {
+    context.fillStyle = colors.foreground;
+    context.fillRect(this.x + 2, this.y + 2, this.w - 4, this.h - 4);
+
+    context.save();
+    context.globalAlpha = 0.22;
+    context.fillStyle = colors.background;
+    context.fillRect(this.x + 5, this.y + 5, this.w - 10, 3);
+    context.fillRect(this.x + 5, this.y + 8, 3, this.h - 16);
+    context.restore();
+  }
+}
+
+export const resetGame = async (state: GameState) => {
+  const pattern = await loadLogoPattern();
+  const left = (CANVAS_WIDTH - LOGO_COLUMNS * BRICK_SIZE) / 2;
+
+  state.score = 0;
+  state.enableGame = false;
+  state.bricks = pattern.flatMap((row, rowIndex) =>
+    [...row].flatMap((pixel, columnIndex) =>
+      pixel === "X"
+        ? [
+            new Brick(
+              left + columnIndex * BRICK_SIZE,
+              LOGO_TOP + rowIndex * BRICK_SIZE,
+              BRICK_SIZE,
+              BRICK_SIZE
+            ),
+          ]
+        : []
+    )
+  );
+};

--- a/apps/web/components/daikanoid/colors.ts
+++ b/apps/web/components/daikanoid/colors.ts
@@ -1,0 +1,19 @@
+export interface GameColors {
+  background: string;
+  foreground: string;
+  mutedForeground: string;
+}
+
+const readColor = (variable: string, fallback: string) => {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(variable)
+    .trim();
+
+  return value || fallback;
+};
+
+export const loadColors = (): GameColors => ({
+  background: readColor("--background", "#ffffff"),
+  foreground: readColor("--foreground", "#171717"),
+  mutedForeground: readColor("--muted-foreground", "#737373"),
+});

--- a/apps/web/components/daikanoid/component.tsx
+++ b/apps/web/components/daikanoid/component.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import { useTheme } from "next-themes";
+import { useEffect, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Ball } from "./ball";
+import { resetGame } from "./brick";
+import { loadColors } from "./colors";
+import {
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  SOUND_BOUNCE_URL,
+  SOUND_BREAK_URL,
+  SOUND_GAME_OVER_URL,
+} from "./constants";
+import { Paddle } from "./paddle";
+import type { GameState } from "./types";
+import { UI } from "./ui";
+
+const createSound = (source: string) => {
+  const sound = new Audio(source);
+  sound.preload = "auto";
+  return sound;
+};
+
+export const Daikanoid = ({
+  className,
+  ...props
+}: Omit<
+  React.ComponentPropsWithRef<"canvas">,
+  "children" | "height" | "width"
+>) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const shouldReduceMotion = useReducedMotion();
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) {
+      return;
+    }
+
+    const colors = loadColors();
+    const soundBounce = createSound(SOUND_BOUNCE_URL);
+    const soundBreak = createSound(SOUND_BREAK_URL);
+    const soundGameOver = createSound(SOUND_GAME_OVER_URL);
+    const state: GameState = {
+      bricks: [],
+      enableGame: false,
+      enableSounds: !shouldReduceMotion,
+      score: 0,
+      soundBounce,
+      soundBreak,
+      soundGameOver,
+    };
+    const ball = new Ball(state);
+    const paddle = new Paddle();
+    const ui = new UI(state);
+    const monoFont =
+      getComputedStyle(document.body).getPropertyValue("--font-mono").trim() ||
+      "monospace";
+
+    let animationFrame = 0;
+    let disposed = false;
+    let previousTime = performance.now();
+
+    const launchBall = async () => {
+      if (state.bricks.length === 0) {
+        await resetGame(state);
+      }
+      if (disposed) {
+        return;
+      }
+
+      state.enableGame = true;
+      ball.reset();
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      paddle.moveTo(event.clientX, canvas.getBoundingClientRect());
+    };
+
+    const handlePointerDown = () => {
+      canvas.focus();
+      void launchBall();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (document.activeElement !== canvas) {
+        return;
+      }
+
+      if (["ArrowLeft", "ArrowRight", "Space"].includes(event.code)) {
+        event.preventDefault();
+      }
+
+      paddle.setKey(event.code, true);
+      if (event.code === "Space") {
+        void launchBall();
+      }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      paddle.setKey(event.code, false);
+    };
+
+    const update = (frameScale: number) => {
+      paddle.move(frameScale);
+      if (!state.enableGame) {
+        return;
+      }
+
+      ball.move(frameScale);
+      ball.checkEdges();
+      ball.checkPaddle(paddle);
+      ball.checkBricks();
+    };
+
+    const draw = () => {
+      context.fillStyle = colors.background;
+      context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+      if (state.bricks.length === 0) {
+        ui.showCompletion(context, colors, monoFont);
+        return;
+      }
+
+      paddle.show(context, colors);
+      ball.show(context, colors);
+      for (const brick of state.bricks) {
+        brick.show(context, colors);
+      }
+      ui.show(context, colors, monoFont);
+    };
+
+    const tick = (time: number) => {
+      const frameScale = Math.min((time - previousTime) / (1000 / 60), 2);
+      previousTime = time;
+      update(frameScale);
+      draw();
+      animationFrame = requestAnimationFrame(tick);
+    };
+
+    canvas.addEventListener("pointermove", handlePointerMove);
+    canvas.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    const start = async () => {
+      await resetGame(state);
+      if (!disposed) {
+        ball.reset();
+        animationFrame = requestAnimationFrame(tick);
+      }
+    };
+
+    void start();
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(animationFrame);
+      canvas.removeEventListener("pointermove", handlePointerMove);
+      canvas.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      soundBounce.pause();
+      soundBreak.pause();
+      soundGameOver.pause();
+    };
+  }, [resolvedTheme, shouldReduceMotion]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_WIDTH}
+      height={CANVAS_HEIGHT}
+      tabIndex={0}
+      aria-label="Page not found. Interactive Breakout game built from the Shadcn Labs logo. Click or press Space to launch, then use the pointer or arrow keys to move."
+      className={cn(
+        "aspect-4/3 h-auto w-full max-w-200 touch-none cursor-none ring-1 ring-border outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+      {...props}
+    />
+  );
+};

--- a/apps/web/components/daikanoid/component.tsx
+++ b/apps/web/components/daikanoid/component.tsx
@@ -121,8 +121,7 @@ export const Daikanoid = ({
     };
 
     const draw = () => {
-      context.fillStyle = colors.background;
-      context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+      context.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
 
       if (state.bricks.length === 0) {
         ui.showCompletion(context, colors, monoFont);

--- a/apps/web/components/daikanoid/constants.ts
+++ b/apps/web/components/daikanoid/constants.ts
@@ -1,0 +1,28 @@
+export const CANVAS_WIDTH = 800;
+export const CANVAS_HEIGHT = 600;
+
+export const BALL_RADIUS = 10;
+export const BALL_SPEED = 8;
+
+export const PADDLE_WIDTH = 96;
+export const PADDLE_HEIGHT = 20;
+export const PADDLE_SPEED = 12;
+export const PADDLE_Y = CANVAS_HEIGHT - PADDLE_HEIGHT - 8;
+
+export const BRICK_SIZE = 40;
+export const BRICK_SCORE = 10;
+
+export const LOGO_COLUMNS = 11;
+export const LOGO_ROWS = 10;
+export const LOGO_TOP = 28;
+
+export const SOUND_BOUNCE_URL =
+  "https://assets.chanhdai.com/sounds/daikanoid/bounce.mp3";
+export const SOUND_BREAK_URL =
+  "https://assets.chanhdai.com/sounds/daikanoid/break.mp3";
+export const SOUND_GAME_OVER_URL =
+  "https://assets.chanhdai.com/sounds/daikanoid/game-over.mp3";
+export const SOUND_VOLUME = 0.3;
+
+export const uncheckedClamp = (min: number, max: number, value: number) =>
+  Math.min(Math.max(value, min), max);

--- a/apps/web/components/daikanoid/index.tsx
+++ b/apps/web/components/daikanoid/index.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { Daikanoid } from "./component";

--- a/apps/web/components/daikanoid/logos.ts
+++ b/apps/web/components/daikanoid/logos.ts
@@ -1,0 +1,53 @@
+import { getLogoMarkSVG } from "@/components/logo";
+
+import { LOGO_COLUMNS, LOGO_ROWS } from "./constants";
+
+const SHADCN_LABS_FALLBACK = [
+  "..X.....X..",
+  ".X..XXX..X.",
+  "X..X......X",
+  "X..X......X",
+  "X...XXX...X",
+  "X.....X...X",
+  "X.....X...X",
+  "X..X..X...X",
+  ".X..XXX..X.",
+  "..X.....X..",
+];
+
+const sampleLogo = async () => {
+  const image = new Image();
+  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+    getLogoMarkSVG("#000000")
+  )}`;
+  await image.decode();
+
+  const sample = document.createElement("canvas");
+  sample.width = LOGO_COLUMNS;
+  sample.height = LOGO_ROWS;
+
+  const context = sample.getContext("2d", { willReadFrequently: true });
+  if (!context) {
+    return SHADCN_LABS_FALLBACK;
+  }
+
+  context.drawImage(image, 0, 0, LOGO_COLUMNS, LOGO_ROWS);
+  const pixels = context.getImageData(0, 0, LOGO_COLUMNS, LOGO_ROWS).data;
+
+  return Array.from({ length: LOGO_ROWS }, (_rowValue, row) =>
+    Array.from({ length: LOGO_COLUMNS }, (_columnValue, column) => {
+      const alpha = pixels[(row * LOGO_COLUMNS + column) * 4 + 3];
+      return alpha > 48 ? "X" : ".";
+    }).join("")
+  );
+};
+
+export const loadLogoPattern = async () => {
+  try {
+    const pattern = await sampleLogo();
+    const brickCount = pattern.join("").replaceAll(".", "").length;
+    return brickCount > 20 ? pattern : SHADCN_LABS_FALLBACK;
+  } catch {
+    return SHADCN_LABS_FALLBACK;
+  }
+};

--- a/apps/web/components/daikanoid/paddle.ts
+++ b/apps/web/components/daikanoid/paddle.ts
@@ -1,0 +1,59 @@
+import type { GameColors } from "./colors";
+import {
+  CANVAS_WIDTH,
+  PADDLE_HEIGHT,
+  PADDLE_SPEED,
+  PADDLE_WIDTH,
+  PADDLE_Y,
+  uncheckedClamp,
+} from "./constants";
+
+export class Paddle {
+  width = PADDLE_WIDTH;
+  height = PADDLE_HEIGHT;
+  x = (CANVAS_WIDTH - PADDLE_WIDTH) / 2;
+  y = PADDLE_Y;
+
+  private moveLeft = false;
+  private moveRight = false;
+
+  show(context: CanvasRenderingContext2D, colors: GameColors) {
+    context.fillStyle = colors.foreground;
+    context.fillRect(this.x, this.y, this.width, this.height);
+
+    context.save();
+    context.globalAlpha = 0.25;
+    context.fillStyle = colors.background;
+    context.fillRect(this.x + 5, this.y + 4, this.width - 10, 3);
+    context.restore();
+  }
+
+  move(frameScale: number) {
+    if (this.moveLeft) {
+      this.x -= PADDLE_SPEED * frameScale;
+    }
+    if (this.moveRight) {
+      this.x += PADDLE_SPEED * frameScale;
+    }
+
+    this.x = uncheckedClamp(0, CANVAS_WIDTH - this.width, this.x);
+  }
+
+  moveTo(clientX: number, bounds: DOMRect) {
+    const pointerX = ((clientX - bounds.left) / bounds.width) * CANVAS_WIDTH;
+    this.x = uncheckedClamp(
+      0,
+      CANVAS_WIDTH - this.width,
+      pointerX - this.width / 2
+    );
+  }
+
+  setKey(code: string, pressed: boolean) {
+    if (code === "ArrowLeft") {
+      this.moveLeft = pressed;
+    }
+    if (code === "ArrowRight") {
+      this.moveRight = pressed;
+    }
+  }
+}

--- a/apps/web/components/daikanoid/preview.tsx
+++ b/apps/web/components/daikanoid/preview.tsx
@@ -32,12 +32,6 @@ const ARTWORK_CLASS_NAME = cn(
   "relative aspect-2/1 w-full overflow-hidden bg-muted/35 ring-1 ring-border"
 );
 
-const SQUARE_GRID_STYLE = {
-  backgroundImage:
-    'url("data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%274%27 height=%274%27 viewBox=%270 0 4 4%27%3E%3Crect width=%271%27 height=%271%27 fill=%27%23888888%27 fill-opacity=%27.22%27/%3E%3C/svg%3E")',
-  backgroundSize: "4px 4px",
-} satisfies React.CSSProperties;
-
 const Brick = ({ active }: { active: boolean }) => (
   <span aria-hidden className="relative aspect-square">
     {active && (
@@ -72,7 +66,7 @@ export const DaikanoidArtwork = ({
     role="img"
     aria-label="404"
     className={cn(ARTWORK_CLASS_NAME, className)}
-    style={{ ...SQUARE_GRID_STYLE, ...style }}
+    style={style}
     {...props}
   >
     <ArtworkBricks />
@@ -105,7 +99,7 @@ export const DaikanoidPreview = ({
         "group cursor-pointer outline-none transition-colors duration-150 hover:bg-muted/55 focus-visible:ring-2 focus-visible:ring-ring",
         className
       )}
-      style={{ ...SQUARE_GRID_STYLE, ...style }}
+      style={style}
       {...props}
     >
       <ArtworkBricks />

--- a/apps/web/components/daikanoid/preview.tsx
+++ b/apps/web/components/daikanoid/preview.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+
+import { cn } from "@/lib/utils";
+
+const DIGIT_FOUR = [
+  "...X.",
+  "..X..",
+  ".X...",
+  "X..X.",
+  "XXXXX",
+  "...X.",
+  "...X.",
+];
+
+const DIGIT_ZERO = [
+  ".XXX.",
+  "X...X",
+  "X...X",
+  "X...X",
+  "X...X",
+  "X...X",
+  ".XXX.",
+];
+
+const NOT_FOUND_PATTERN = DIGIT_FOUR.map(
+  (row, index) => `${row}.${DIGIT_ZERO[index]}.${row}`
+);
+
+const ARTWORK_CLASS_NAME = cn(
+  "relative aspect-2/1 w-full overflow-hidden bg-muted/35 ring-1 ring-border"
+);
+
+const SQUARE_GRID_STYLE = {
+  backgroundImage:
+    'url("data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%274%27 height=%274%27 viewBox=%270 0 4 4%27%3E%3Crect width=%271%27 height=%271%27 fill=%27%23888888%27 fill-opacity=%27.22%27/%3E%3C/svg%3E")',
+  backgroundSize: "4px 4px",
+} satisfies React.CSSProperties;
+
+const Brick = ({ active }: { active: boolean }) => (
+  <span aria-hidden className="relative aspect-square">
+    {active && (
+      <span className="absolute inset-0.5 bg-foreground">
+        <span className="absolute top-1 right-1 left-1 h-0.5 bg-background/20" />
+        <span className="absolute top-1 bottom-1 left-1 w-0.5 bg-background/20" />
+      </span>
+    )}
+  </span>
+);
+
+const ArtworkBricks = () => (
+  <span
+    aria-hidden
+    className="absolute inset-x-[7%] top-1/2 grid -translate-y-1/2 gap-0.5"
+    style={{ gridTemplateColumns: "repeat(17, minmax(0, 1fr))" }}
+  >
+    {NOT_FOUND_PATTERN.flatMap((row, rowIndex) =>
+      [...row].map((brick, columnIndex) => (
+        <Brick active={brick === "X"} key={`${rowIndex}-${columnIndex}`} />
+      ))
+    )}
+  </span>
+);
+
+export const DaikanoidArtwork = ({
+  className,
+  style,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    role="img"
+    aria-label="404"
+    className={cn(ARTWORK_CLASS_NAME, className)}
+    style={{ ...SQUARE_GRID_STYLE, ...style }}
+    {...props}
+  >
+    <ArtworkBricks />
+  </div>
+);
+
+export interface DaikanoidPreviewProps extends Omit<
+  React.ComponentProps<typeof motion.button>,
+  "children"
+> {
+  className?: string;
+}
+
+export const DaikanoidPreview = ({
+  className,
+  style,
+  ...props
+}: DaikanoidPreviewProps) => {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <motion.button
+      type="button"
+      aria-label="Play the 404 brick breaker game"
+      initial="idle"
+      whileHover={shouldReduceMotion ? "idle" : "hover"}
+      whileFocus={shouldReduceMotion ? "idle" : "hover"}
+      className={cn(
+        ARTWORK_CLASS_NAME,
+        "group cursor-pointer outline-none transition-colors duration-150 hover:bg-muted/55 focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+      style={{ ...SQUARE_GRID_STYLE, ...style }}
+      {...props}
+    >
+      <ArtworkBricks />
+
+      <motion.span
+        variants={{
+          hover: {
+            opacity: [1, 0.42, 1, 0.64, 1],
+            transition: { duration: 0.32, times: [0, 0.18, 0.42, 0.68, 1] },
+          },
+          idle: { opacity: 1 },
+        }}
+        className="absolute top-1/2 left-1/2 z-10 inline-flex min-h-14 min-w-32 -translate-x-1/2 -translate-y-1/2 items-center justify-center bg-foreground/70 px-6 font-mono text-background text-base transition-colors duration-150 group-hover:bg-foreground/85 group-focus-visible:bg-foreground/85"
+      >
+        Play
+      </motion.span>
+    </motion.button>
+  );
+};

--- a/apps/web/components/daikanoid/types.ts
+++ b/apps/web/components/daikanoid/types.ts
@@ -1,0 +1,11 @@
+import type { Brick } from "./brick";
+
+export interface GameState {
+  bricks: Brick[];
+  enableGame: boolean;
+  enableSounds: boolean;
+  score: number;
+  soundBounce: HTMLAudioElement;
+  soundBreak: HTMLAudioElement;
+  soundGameOver: HTMLAudioElement;
+}

--- a/apps/web/components/daikanoid/ui.ts
+++ b/apps/web/components/daikanoid/ui.ts
@@ -1,0 +1,60 @@
+import type { GameColors } from "./colors";
+import { CANVAS_HEIGHT, CANVAS_WIDTH, PADDLE_Y } from "./constants";
+import type { GameState } from "./types";
+
+export class UI {
+  private state: GameState;
+
+  constructor(state: GameState) {
+    this.state = state;
+  }
+
+  show(
+    context: CanvasRenderingContext2D,
+    colors: GameColors,
+    monoFont: string
+  ) {
+    this.showScore(context, colors, monoFont);
+
+    if (!this.state.enableGame) {
+      context.fillStyle = colors.mutedForeground;
+      context.font = `400 12px ${monoFont}`;
+      context.textAlign = "center";
+      context.textBaseline = "bottom";
+      context.fillText(
+        "CLICK OR PRESS SPACE TO LAUNCH",
+        CANVAS_WIDTH / 2,
+        PADDLE_Y - 18
+      );
+    }
+  }
+
+  showCompletion(
+    context: CanvasRenderingContext2D,
+    colors: GameColors,
+    monoFont: string
+  ) {
+    this.showScore(context, colors, monoFont);
+    context.fillStyle = colors.foreground;
+    context.font = `500 80px ${monoFont}`;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText("404", CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 10);
+  }
+
+  private showScore(
+    context: CanvasRenderingContext2D,
+    colors: GameColors,
+    monoFont: string
+  ) {
+    context.fillStyle = colors.foreground;
+    context.font = `400 16px ${monoFont}`;
+    context.textAlign = "right";
+    context.textBaseline = "top";
+    context.fillText(
+      this.state.score.toString().padStart(3, "0"),
+      CANVAS_WIDTH - 4,
+      4
+    );
+  }
+}

--- a/apps/web/components/not-found.tsx
+++ b/apps/web/components/not-found.tsx
@@ -124,7 +124,7 @@ export const NotFound = () => {
               <motion.div
                 layoutId={GAME_TRANSITION_NAME}
                 transition={gameTransition}
-                className="aspect-4/3 w-full overflow-hidden bg-background ring-1 ring-border"
+                className="aspect-4/3 w-full overflow-hidden bg-muted/35 ring-1 ring-border"
               >
                 <Daikanoid
                   autoFocus

--- a/apps/web/components/not-found.tsx
+++ b/apps/web/components/not-found.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { ArrowLeftIcon, BookOpenTextIcon } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import Link from "next/link";
+import { useState } from "react";
+
+import { Daikanoid } from "@/components/daikanoid";
+import {
+  DaikanoidArtwork,
+  DaikanoidPreview,
+} from "@/components/daikanoid/preview";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ROUTES } from "@/constants/routes";
+
+const GAME_TRANSITION_NAME = "not-found-daikanoid";
+const GAME_TRANSITION = {
+  duration: 0.42,
+  ease: [0.4, 0, 0.2, 1],
+} as const;
+
+const NotFoundActions = () => (
+  <div className="flex flex-wrap items-center justify-center gap-2">
+    <Button asChild variant="outline">
+      <Link href={ROUTES.HOME}>
+        <ArrowLeftIcon />
+        Back to Home
+      </Link>
+    </Button>
+    <Button asChild>
+      <Link href={ROUTES.DOCS}>
+        <BookOpenTextIcon />
+        Go to Docs
+      </Link>
+    </Button>
+  </div>
+);
+
+const NotFoundCopy = () => (
+  <>
+    <EmptyTitle className="text-xl md:text-2xl">
+      <h1>Page not found</h1>
+    </EmptyTitle>
+    <EmptyDescription className="max-w-md md:text-base/relaxed">
+      The page you're looking for may have been moved, removed, renamed, or
+      might never have existed.
+    </EmptyDescription>
+  </>
+);
+
+export const NotFound = () => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
+  const gameTransition = shouldReduceMotion ? { duration: 0 } : GAME_TRANSITION;
+
+  return (
+    <main className="relative grid min-h-svh place-items-center overflow-hidden p-6 md:p-8">
+      <Empty className="w-full max-w-md gap-6 p-0 md:hidden">
+        <EmptyHeader className="w-full max-w-md">
+          <EmptyMedia className="mb-3 w-full">
+            <DaikanoidArtwork />
+          </EmptyMedia>
+          <NotFoundCopy />
+        </EmptyHeader>
+        <EmptyContent>
+          <NotFoundActions />
+        </EmptyContent>
+      </Empty>
+
+      <AnimatePresence initial={false}>
+        {!isPlaying && (
+          <motion.div
+            key="not-found-empty"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.16 }}
+            className="hidden w-full max-w-3xl md:block"
+          >
+            <Empty className="w-full gap-6 p-0">
+              <EmptyHeader className="w-full max-w-3xl gap-3">
+                <EmptyMedia className="mb-5 w-full">
+                  <DaikanoidPreview
+                    layoutId={GAME_TRANSITION_NAME}
+                    transition={gameTransition}
+                    onClick={() => setIsPlaying(true)}
+                  />
+                </EmptyMedia>
+                <NotFoundCopy />
+              </EmptyHeader>
+              <EmptyContent>
+                <NotFoundActions />
+              </EmptyContent>
+            </Empty>
+          </motion.div>
+        )}
+
+        {isPlaying && (
+          <motion.div
+            key="not-found-game"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
+            className="absolute inset-0 z-20 hidden place-items-center bg-background p-6 md:grid"
+          >
+            <div className="flex w-[min(50rem,calc(100vw-3rem),calc(133.333svh-7.667rem))] flex-col items-start gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setIsPlaying(false)}
+              >
+                <ArrowLeftIcon />
+                Back
+              </Button>
+              <motion.div
+                layoutId={GAME_TRANSITION_NAME}
+                transition={gameTransition}
+                className="aspect-4/3 w-full overflow-hidden bg-background ring-1 ring-border"
+              >
+                <Daikanoid
+                  autoFocus
+                  className="h-full w-full max-w-none ring-0 focus-visible:ring-0"
+                />
+              </motion.div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </main>
+  );
+};

--- a/apps/web/components/ui/empty.tsx
+++ b/apps/web/components/ui/empty.tsx
@@ -1,0 +1,96 @@
+import { cva } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const Empty = ({ className, ...props }: React.ComponentProps<"div">) => (
+  <div
+    data-slot="empty"
+    className={cn(
+      "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+      className
+    )}
+    {...props}
+  />
+);
+
+const EmptyHeader = ({ className, ...props }: React.ComponentProps<"div">) => (
+  <div
+    data-slot="empty-header"
+    className={cn(
+      "flex max-w-sm flex-col items-center gap-2 text-center",
+      className
+    )}
+    {...props}
+  />
+);
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    defaultVariants: {
+      variant: "default",
+    },
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+  }
+);
+
+const EmptyMedia = ({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) => (
+  <div
+    data-slot="empty-icon"
+    data-variant={variant}
+    className={cn(emptyMediaVariants({ className, variant }))}
+    {...props}
+  />
+);
+
+const EmptyTitle = ({ className, ...props }: React.ComponentProps<"div">) => (
+  <div
+    data-slot="empty-title"
+    className={cn("text-lg font-medium tracking-tight", className)}
+    {...props}
+  />
+);
+
+const EmptyDescription = ({
+  className,
+  ...props
+}: React.ComponentProps<"p">) => (
+  <div
+    data-slot="empty-description"
+    className={cn(
+      "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+      className
+    )}
+    {...props}
+  />
+);
+
+const EmptyContent = ({ className, ...props }: React.ComponentProps<"div">) => (
+  <div
+    data-slot="empty-content"
+    className={cn(
+      "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+      className
+    )}
+    {...props}
+  />
+);
+
+export {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+};


### PR DESCRIPTION
## Summary

- add a responsive shadcn Empty-based not-found page with static mobile artwork
- add a modular Daikanoid canvas game built from the Shadcn Labs logo, including sound effects
- add a square-grid 404 preview with a Motion shared-layout transition into the game
- keep the mobile artwork non-interactive and place a ghost Back button above the desktop canvas

## Verification

- pnpm exec ultracite check apps/web/app/not-found.tsx apps/web/components/not-found.tsx apps/web/components/ui/empty.tsx apps/web/components/daikanoid
- pnpm --filter web typecheck
- pnpm --filter web exec next build --webpack
- responsive layout checks at 320px, 767px, and 768x600